### PR TITLE
Add Dockerfile to build bash image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.8
+
+RUN apk upgrade --no-cache && \
+    apk add --no-cache bash~=4.4
+
+ENTRYPOINT ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # ci-bash-task
+
+Minimal Alpine based image for running bash-based tasks as part of a Concourse pipeline.


### PR DESCRIPTION
Added Dockerfile to build a minimal Alpine-based image for running bash tasks in Concourse
Updated README

Resolves: DVOP-1491